### PR TITLE
Add basic dashboard page and global styles

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,0 +1,25 @@
+export default function Dashboard() {
+  return (
+    <div className="dashboard">
+      <h1>Dashboard</h1>
+      <div className="grid">
+        <div className="card">
+          <h2>today's money</h2>
+          <p>$53,000</p>
+        </div>
+        <div className="card">
+          <h2>today's users</h2>
+          <p>2,300</p>
+        </div>
+        <div className="card">
+          <h2>new clients</h2>
+          <p>+3,462</p>
+        </div>
+        <div className="card">
+          <h2>sales</h2>
+          <p>$103,430</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,27 @@
+html, body {
+  padding: 0;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background-color: #f0f2f5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.dashboard {
+  padding: 2rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 6px;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
## Summary
- add global stylesheet and app wrapper
- create placeholder dashboard page with statistic cards

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68942b56564c83208135d0fc5ccdfa59