### PR TITLE
Add basic map rendering, menu button, and character sprite

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,11 +1,59 @@
 import Head from 'next/head';
 import { useEffect, useRef } from 'react';
-import { Box, Button } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+} from '@chakra-ui/react';
+import { HamburgerIcon } from '@chakra-ui/icons';
 import { useColorMode } from '@chakra-ui/react';
+
+const TILE_SIZE = 20;
+const mapData = [
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GWWWGGGGMMMMGGGGGGGG',
+  'GWWWGGGGMMMMGGGGGGGG',
+  'GGGGGGGGMMMMGGGGGGGG',
+  'GGGGDDDDMMMMGGGGGGGG',
+  'GGGGDDDDGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGWWWGGGG',
+  'GGGGGGGGGGGGGWWWGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+  'GGGGGGGGGGGGGGGGGGGG',
+];
+
+const tileColors = {
+  G: '#7cfc00', // grass
+  W: '#1e90ff', // water
+  M: '#a9a9a9', // mountain
+  D: '#deb887', // desert
+};
+
+const playerSprite = [
+  ' 111 ',
+  '11111',
+  ' 101 ',
+  '11111',
+  '1   1',
+];
 
 export default function Home() {
   const canvasRef = useRef(null);
-  const playerRef = useRef({ x: 50, y: 50 });
+  const playerRef = useRef({ x: 0, y: 0 });
   const { colorMode, toggleColorMode } = useColorMode();
 
   useEffect(() => {
@@ -16,28 +64,56 @@ export default function Home() {
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
 
+    const drawMap = () => {
+      mapData.forEach((row, r) => {
+        [...row].forEach((tile, c) => {
+          ctx.fillStyle = tileColors[tile] || '#000';
+          ctx.fillRect(c * TILE_SIZE, r * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+        });
+      });
+    };
+
+    const drawPlayer = () => {
+      const pixelSize = TILE_SIZE / playerSprite.length;
+      playerSprite.forEach((row, r) => {
+        [...row].forEach((pixel, c) => {
+          if (pixel === '1') {
+            ctx.fillStyle = 'teal';
+            ctx.fillRect(
+              playerRef.current.x + c * pixelSize,
+              playerRef.current.y + r * pixelSize,
+              pixelSize,
+              pixelSize
+            );
+          }
+        });
+      });
+    };
+
     const draw = () => {
       ctx.fillStyle = colorMode === 'dark' ? '#000' : '#fff';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
-      ctx.fillStyle = 'teal';
-      ctx.fillRect(playerRef.current.x, playerRef.current.y, 20, 20);
+      drawMap();
+      drawPlayer();
     };
 
     draw();
 
     const handleKey = (e) => {
+      const maxX = canvas.width - TILE_SIZE;
+      const maxY = canvas.height - TILE_SIZE;
       switch (e.key) {
         case 'ArrowUp':
-          playerRef.current.y = Math.max(0, playerRef.current.y - 5);
+          playerRef.current.y = Math.max(0, playerRef.current.y - TILE_SIZE);
           break;
         case 'ArrowDown':
-          playerRef.current.y = Math.min(canvas.height - 20, playerRef.current.y + 5);
+          playerRef.current.y = Math.min(maxY, playerRef.current.y + TILE_SIZE);
           break;
         case 'ArrowLeft':
-          playerRef.current.x = Math.max(0, playerRef.current.x - 5);
+          playerRef.current.x = Math.max(0, playerRef.current.x - TILE_SIZE);
           break;
         case 'ArrowRight':
-          playerRef.current.x = Math.min(canvas.width - 20, playerRef.current.x + 5);
+          playerRef.current.x = Math.min(maxX, playerRef.current.x + TILE_SIZE);
           break;
         default:
           return;
@@ -56,14 +132,29 @@ export default function Home() {
         <title>Whale</title>
         <meta name="description" content="Client-side canvas game" />
       </Head>
-      <Box textAlign="center" p={4}>
+      <Box textAlign="center" p={4} position="relative">
+        <Menu placement="bottom-end">
+          <MenuButton
+            as={IconButton}
+            icon={<HamburgerIcon />}
+            borderRadius="full"
+            position="absolute"
+            top={4}
+            right={4}
+            aria-label="Open menu"
+          />
+          <MenuList>
+            <MenuItem>Inventory</MenuItem>
+            <MenuItem>Settings</MenuItem>
+          </MenuList>
+        </Menu>
         <Button mb={4} onClick={toggleColorMode}>
           Toggle {colorMode === 'light' ? 'Dark' : 'Light'} Mode
         </Button>
         <canvas
           ref={canvasRef}
-          width={300}
-          height={150}
+          width={mapData[0].length * TILE_SIZE}
+          height={mapData.length * TILE_SIZE}
           aria-label="Game area"
         />
       </Box>


### PR DESCRIPTION
## Summary
- render colored tile map with grass, water, mountains, and desert
- draw simple character sprite and movement aligned to grid
- add circular menu button in top-right for quick navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b13040a79483209d8d1e42f742ee64